### PR TITLE
fix: type error in Example.tsx

### DIFF
--- a/src/core/Example.tsx
+++ b/src/core/Example.tsx
@@ -1,7 +1,7 @@
 /* eslint react-hooks/exhaustive-deps: 1 */
 import * as React from 'react'
 import * as THREE from 'three'
-import { type Color } from '@react-three/fiber'
+import type { Color } from '@react-three/fiber'
 
 import { Text3D } from './Text3D'
 import { Center } from './Center'


### PR DESCRIPTION
Found I was having this type error in my node_modules when running type check in my project.

This looks to be due to an incorrect syntax when importing this type, although I might be unaware of a newer TS feature.

```
node_modules/@react-three/drei/core/Example.d.ts:2:15 - error TS1005: ',' expected.

2 import { type Color } from '@react-three/fiber';
```

<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

### Why

<!-- What changes are being made? What feature/bug is being fixed here? If you are closing an issue, use the keyword 'resolves' to link the issue automatically -->

### What

<!-- what have you done, if its a bug, whats your solution? -->

### Checklist

<!-- Have you done all of these things?  -->

<!--
To check an item, place an "x" in the box like so: "- [x] Documentation"
Remove items that are irrelevant to your changes.
-->

- [ ] Documentation updated ([example](https://github.com/pmndrs/drei/blob/master/README.md#example))
- [ ] Storybook entry added ([example](https://github.com/pmndrs/drei/blob/master/.storybook/stories/Example.stories.tsx))
- [ ] Ready to be merged

<!-- if you untick ready to be merged & you haven't submitted as a draft, we will change it to draft. -->

<!-- feel free to add additional comments -->
